### PR TITLE
Fix missing dependency on nette/utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     "php": ">=7.1",
     "ext-json": "*",
     "ext-soap": "*",
-    "ext-hash": "*"
+    "ext-hash": "*",
+    "nette/utils": "^2.4 || ^3.0"
   },
   "require-dev": {
-    "nette/utils": "^2.4 || ^3.0",
     "ninjify/qa": "^0.9.0",
     "ninjify/nunjuck": "^0.2.1"
   },


### PR DESCRIPTION
`Tp\Escaper` is dependent on `Nette\Utils\Json`, yet `nette/utils` is not listed as non-dev dependency.

Not sure if you'd rather implement Escaper without the dependency, but here's a one way to fix it :)